### PR TITLE
Fix to set-max-objective and set-min-objective contracts

### DIFF
--- a/nlopt/docs/unsafe.scrbl
+++ b/nlopt/docs/unsafe.scrbl
@@ -38,7 +38,7 @@ will probably cause Racket to crash.}
                             [f (-> natural-number/c
                                    cpointer?
                                    (or/c cpointer? #f)
-                                   any/c
+                                   cpointer?
                                    flonum?)]
                             [data any/c])
          symbol?]{
@@ -51,7 +51,7 @@ will probably cause Racket to crash.}
                             [f (-> natural-number/c
                                    cpointer?
                                    (or/c cpointer? #f)
-                                   any/c
+                                   cpointer?
                                    flonum?)]
                             [data any/c])
          symbol?]{


### PR DESCRIPTION
The FFI implementation expects the "data" position of these functions
to be cpointers rather than any. See definition of _nlopt_func on line 185 of unsafe.rkt.