### PR TITLE
Fix FFI interface to add-equality-constraint and add-inequality-const…

### DIFF
--- a/nlopt/docs/unsafe.scrbl
+++ b/nlopt/docs/unsafe.scrbl
@@ -98,7 +98,7 @@ will probably cause Racket to crash.}
                                     [f (-> nlopt-opt?
                                            cpointer?
                                            (or/c cpointer? #f)
-                                           any/c
+                                           cpointer?
                                            flonum?)]
                                     [data any/c]
                                     [tolerance real?])
@@ -112,7 +112,7 @@ will probably cause Racket to crash.}
                                   [f (-> nlopt-opt?
                                          cpointer?
                                          (or/c cpointer? #f)
-                                         any/c
+                                         cpointer?
                                          flonum?)]
                                   [data any/c]
                                   [tolerance real?])


### PR DESCRIPTION
…raint

data position is a cpointer rather than any/c
See lines 238 and 248 of unsafe.rkt