### PR TITLE
expose get_num_evals only when available (Take 2)

### DIFF
--- a/nlopt/unsafe.rkt
+++ b/nlopt/unsafe.rkt
@@ -331,4 +331,12 @@
 (define _nlopt_munge (_fun _pointer -> _pointer))
 (defnlopt set-munge : _nlopt_opt _nlopt_munge _nlopt_munge -> _void)
 
+;; New in 2.5.0: nlopt_get_numevals
+(require ffi/unsafe/define)
+(define-ffi-definer define-nlopt libnlopt
+  #:default-make-fail make-not-available)
+
+(define-nlopt get-numevals (_fun _nlopt_opt -> _int)
+  #:c-id nlopt_get_numevals)
+(provide get-numevals)
 


### PR DESCRIPTION
Exploiting the make-fail facility of ffi/unsafe so that get-num-evals simply gives a "not available" error at runtime if it is not available from the available version of libnlopt.
(see:
 https://docs.racket-lang.org/foreign/Defining_Bindings.html?q=define-ffi-definer#%28form._%28%28lib._ffi%2Funsafe%2Fdefine..rkt%29._define-ffi-definer%29%29 
)

I failed to install 2.4.2 to test this, but failure can be simulated by munging the name "nlopt_get_numevals" in some way so that the function is not found.