### PR TITLE
Updated _nlopt_func signature (primarily to fix a memory error)

### DIFF
--- a/nlopt/unsafe.rkt
+++ b/nlopt/unsafe.rkt
@@ -188,7 +188,11 @@
 
 (defnlopt optimize : _nlopt_opt _pointer (opt_f : (_peg-ptr o _double)) -> (res : _nlopt_result) -> (values res opt_f))
 
-(define _nlopt_func (_fun (n : _uint) _pointer (_or-null _pointer) _pointer -> _double))
+;; #:keep protects callbacks from premature garbage collection, because NLopt retains them
+(define _nlopt_func
+  (_fun #:keep (box '()) 
+        _uint _gcpointer _gcpointer _gcpointer ->
+        _double))
 
 (define (objective-wrapper raw)
   (lambda (o f d)


### PR DESCRIPTION
1) Since NLopt retains nlopt_func objects, their corresponding C callbacks must be kept to prevent garbage collection.
Added #:keep directive with a boxed list to maintain multiple nlopt_funcs. 
See documentation for _cprocedure:
https://docs.racket-lang.org/foreign/foreign_procedures.html?q=_cprocedure#%28def._%28%28lib._ffi%2Funsafe..rkt%29.__cprocedure%29%29
(I uncovered this while translating the NLopt C tutorial to Racket: forcing garbage collection in the callback consistently
crashed Dr. Racket).

2) Switched _pointer to _gcpointer since the associated memory may be under control of Racket GC
3) removed _or-null because it is already implied by both _pointer and _gcpointer, so redundant.