### PR TITLE
semantics of regexp-replaces changed btw Racket v7.9 and v8.3

### DIFF
--- a/nlopt/unsafe.rkt
+++ b/nlopt/unsafe.rkt
@@ -101,7 +101,7 @@
 		  (regexp-replaces
 		   (symbol->string (syntax->datum n))
 		   '((#rx"-" "_")
-		     [#rx"(.*)$" "nlopt_\\1"]
+		     [#rx"^(.*)$" "nlopt_\\1"]
 		     (#rx"!$" ""))))))
 
 (define-syntax (defnlopt stx)


### PR DESCRIPTION
regexp-replaces now as-advertised follows regexp-replace*, so need to modify the regexp to avoid matching the empty end of the string, and only match the entire string.